### PR TITLE
Stop polling once cluster is in error state

### DIFF
--- a/src/clusters.ts
+++ b/src/clusters.ts
@@ -52,7 +52,12 @@ export async function pollForStatus(vendorPortalApi: VendorPortalApi, clusterId:
       if (clusterDetails.status === expectedStatus) {
         return clusterDetails;
       }
-  
+
+      // Once state is "error", it will never change. So we can shortcut polling.
+      if (clusterDetails.status === "error") {
+        throw new Error(`Cluster has entered error state.`);
+      }
+
       console.debug(`Cluster status is ${clusterDetails.status}, sleeping for ${sleeptime} seconds`);
       await new Promise(f => setTimeout(f, sleeptime*1000));
     }


### PR DESCRIPTION
Once cluster enters error state, it will not transition into any other state. This reduces time callers of `pollForStatus` have to wait.