### PR TITLE
add disk, node, and instance type for create cluster

### DIFF
--- a/dist/clusters.d.ts
+++ b/dist/clusters.d.ts
@@ -8,7 +8,7 @@ export declare class ClusterVersion {
     name: string;
     version: string;
 }
-export declare function createCluster(vendorPortalApi: VendorPortalApi, clusterName: string, k8sDistribution: string, k8sVersion: string, clusterTTL: string): Promise<Cluster>;
+export declare function createCluster(vendorPortalApi: VendorPortalApi, clusterName: string, k8sDistribution: string, k8sVersion: string, clusterTTL: string, diskGib?: number, nodeCount?: number, instanceType?: string): Promise<Cluster>;
 export declare function pollForStatus(vendorPortalApi: VendorPortalApi, clusterId: string, expectedStatus: string, timeout?: number): Promise<Cluster>;
 export declare function getKubeconfig(vendorPortalApi: VendorPortalApi, clusterId: string): Promise<string>;
 export declare function removeCluster(vendorPortalApi: VendorPortalApi, clusterId: string): Promise<void>;

--- a/dist/clusters.js
+++ b/dist/clusters.js
@@ -7,15 +7,19 @@ exports.Cluster = Cluster;
 class ClusterVersion {
 }
 exports.ClusterVersion = ClusterVersion;
-async function createCluster(vendorPortalApi, clusterName, k8sDistribution, k8sVersion, clusterTTL) {
+async function createCluster(vendorPortalApi, clusterName, k8sDistribution, k8sVersion, clusterTTL, diskGib, nodeCount, instanceType) {
     const http = await vendorPortalApi.client();
     const reqBody = {
         "name": clusterName,
         "kubernetes_distribution": k8sDistribution,
         "kubernetes_version": k8sVersion,
         "ttl": clusterTTL,
-        "disk_gib": 50,
+        "disk_gib": diskGib || 50,
+        "node_count": nodeCount || 1,
     };
+    if (instanceType !== undefined) {
+        reqBody["instance_type"] = instanceType;
+    }
     const uri = `${vendorPortalApi.endpoint}/cluster`;
     const res = await http.post(uri, JSON.stringify(reqBody));
     if (res.message.statusCode != 201) {

--- a/dist/clusters.js
+++ b/dist/clusters.js
@@ -16,10 +16,8 @@ async function createCluster(vendorPortalApi, clusterName, k8sDistribution, k8sV
         "ttl": clusterTTL,
         "disk_gib": diskGib || 50,
         "node_count": nodeCount || 1,
+        "instance_type": instanceType
     };
-    if (instanceType !== undefined) {
-        reqBody["instance_type"] = instanceType;
-    }
     const uri = `${vendorPortalApi.endpoint}/cluster`;
     const res = await http.post(uri, JSON.stringify(reqBody));
     if (res.message.statusCode != 201) {

--- a/dist/clusters.spec.js
+++ b/dist/clusters.spec.js
@@ -15,6 +15,7 @@ describe('ClusterService', () => {
             kubernetes_version: "v1.25.1",
             ttl: "10m",
             disk_gib: 50,
+            node_count: 1,
         };
         globalThis.provider.addInteraction({
             state: 'cluster created',

--- a/pacts/npm_consumer-vp_service.json
+++ b/pacts/npm_consumer-vp_service.json
@@ -74,6 +74,7 @@
           "kubernetes_distribution": "kind",
           "kubernetes_version": "v1.25.1",
           "name": "cluster1",
+          "node_count": 1,
           "ttl": "10m"
         },
         "headers": {

--- a/src/clusters.spec.ts
+++ b/src/clusters.spec.ts
@@ -16,6 +16,7 @@ describe('ClusterService', () => {
             kubernetes_version: "v1.25.1",
             ttl: "10m",
             disk_gib: 50,
+            node_count: 1,
         }
         globalThis.provider.addInteraction({
             state: 'cluster created',

--- a/src/clusters.ts
+++ b/src/clusters.ts
@@ -11,7 +11,7 @@ export class ClusterVersion {
   version: string;
 }
 
-export async function createCluster(vendorPortalApi: VendorPortalApi, clusterName: string, k8sDistribution: string, k8sVersion: string, clusterTTL: string): Promise<Cluster> {
+export async function createCluster(vendorPortalApi: VendorPortalApi, clusterName: string, k8sDistribution: string, k8sVersion: string, clusterTTL: string, diskGib?: number, nodeCount?: number, instanceType?: string): Promise<Cluster> {
     const http = await vendorPortalApi.client();
 
     const reqBody = {
@@ -19,8 +19,14 @@ export async function createCluster(vendorPortalApi: VendorPortalApi, clusterNam
         "kubernetes_distribution": k8sDistribution,
         "kubernetes_version": k8sVersion,
         "ttl": clusterTTL,
-        "disk_gib": 50,
+        "disk_gib": diskGib || 50,
+        "node_count": nodeCount || 1,
     }
+
+    if (instanceType !== undefined) {
+      reqBody["instance_type"] = instanceType;
+    }
+
     const uri = `${vendorPortalApi.endpoint}/cluster`;
     const res = await http.post(uri, JSON.stringify(reqBody));
     if (res.message.statusCode != 201) {

--- a/src/clusters.ts
+++ b/src/clusters.ts
@@ -21,10 +21,7 @@ export async function createCluster(vendorPortalApi: VendorPortalApi, clusterNam
         "ttl": clusterTTL,
         "disk_gib": diskGib || 50,
         "node_count": nodeCount || 1,
-    }
-
-    if (instanceType !== undefined) {
-      reqBody["instance_type"] = instanceType;
+        "instance_type": instanceType
     }
 
     const uri = `${vendorPortalApi.endpoint}/cluster`;


### PR DESCRIPTION
Adds optional parameters for `disk_gib`, `node_count`, and `instance_type` to the `createCluster` function. Disk will default to 50 and nodes to 1 to align with the behavior of the CLI.