### PR TITLE
fix: resolve critical and high severity npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,9 +1516,9 @@
             }
         },
         "node_modules/@jest/reporters/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2871,15 +2871,15 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/babel-jest": {
@@ -3081,9 +3081,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-            "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3116,9 +3116,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -4828,9 +4828,9 @@
             }
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5454,9 +5454,9 @@
             }
         },
         "node_modules/jest-config/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5814,9 +5814,9 @@
             }
         },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6145,9 +6145,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -7231,9 +7231,9 @@
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -7476,11 +7476,14 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/pump": {
             "version": "3.0.4",

--- a/src/customers.spec.ts
+++ b/src/customers.spec.ts
@@ -30,7 +30,7 @@ describe("Archive Customer", () => {
         expect(true).toEqual(true);
       })
       .catch(err => {
-        fail(err);
+        throw err;
       });
   });
 });

--- a/src/releases.spec.ts
+++ b/src/releases.spec.ts
@@ -45,7 +45,7 @@ describe("Promote Release", () => {
         expect(true).toEqual(true);
       })
       .catch(err => {
-        fail(err);
+        throw err;
       });
   });
 });
@@ -75,7 +75,7 @@ describe("Report Results", () => {
         expect(true).toEqual(true);
       })
       .catch(err => {
-        fail(err);
+        throw err;
       });
   });
 });
@@ -112,7 +112,7 @@ describe("Get Release", () => {
         expect(true).toEqual(true);
       })
       .catch(err => {
-        fail(err);
+        throw err;
       });
   });
 });


### PR DESCRIPTION
## Summary

- Updates `package-lock.json` via `npm audit fix` to resolve 6 open Dependabot vulnerabilities (2 critical, 3 high, 1 moderate)
- No changes to `package.json` — all fixes were to indirect/transitive dependencies

## Vulnerabilities Fixed

| Package | Severity | Advisory |
|---------|----------|----------|
| `axios` ≤1.14.0 | **Critical** | SSRF via NO_PROXY bypass ([GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5)) and header injection ([GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx)) |
| `handlebars` ≤4.7.8 | **Critical/High** | JS injection via AST type confusion and prototype pollution (multiple CVEs) |
| `basic-ftp` ≤5.2.1 | High | CRLF injection / FTP command injection ([GHSA-6v7q-wjvx-w8wg](https://github.com/advisories/GHSA-6v7q-wjvx-w8wg), [GHSA-chqc-8p9q-pq6q](https://github.com/advisories/GHSA-chqc-8p9q-pq6q)) |
| `lodash` ≤4.17.23 | High | Code injection and prototype pollution ([GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc), [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh)) |
| `path-to-regexp` 8.0.0–8.3.0 | High | ReDoS via sequential optional groups ([GHSA-j3q9-mxjg-w52f](https://github.com/advisories/GHSA-j3q9-mxjg-w52f), [GHSA-27v5-c462-wpq7](https://github.com/advisories/GHSA-27v5-c462-wpq7)) |
| `brace-expansion` | Moderate | Process hang / memory exhaustion via zero-step sequence |

These are all **devDependencies** (via `@pact-foundation/pact`, `ts-jest`, `mockttp`, `get-uri`) and do not affect published library consumers.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities after fix
- [x] All 46 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)