### PR TITLE
fix: resolve dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3081,9 +3081,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4495,9 +4495,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

Resolves open Dependabot security alerts:

**npm (package-lock.json):**
- `follow-redirects` — MEDIUM leaks Custom Authentication Headers to Cross-Domain Redirect Targets

## Test plan
- [ ] npm build passes
- [ ] npm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)