### PR TITLE
feat: add VM lifecycle support (createVM, pollForVMStatus, removeVM)

### DIFF
--- a/pacts/npm_consumer-vp_service.json
+++ b/pacts/npm_consumer-vp_service.json
@@ -126,6 +126,37 @@
       }
     },
     {
+      "description": "a request for creating a vm",
+      "providerState": "vm created",
+      "request": {
+        "body": {
+          "distribution": "ubuntu",
+          "name": "vm1",
+          "ttl": "10m"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/vm"
+      },
+      "response": {
+        "body": {
+          "vms": [
+            {
+              "id": "1234abcd",
+              "name": "vm1",
+              "status": "provisioning"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 201
+      }
+    },
+    {
       "description": "a request for promoting a release",
       "providerState": "release promoted",
       "request": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export { Channel, createChannel, getChannelDetails, archiveChannel, pollForAirga
 export { ClusterVersion, createCluster, createClusterWithLicense, pollForStatus, getKubeconfig, removeCluster, upgradeCluster, getClusterVersions, createAddonObjectStore, pollForAddonStatus, exposeClusterPort } from "./clusters";
 export { KubernetesDistribution, CustomerSummary, CreateCustomerOptions, archiveCustomer, createCustomer, getUsedKubernetesDistributions, listCustomersByName, listCustomersByEmail } from "./customers";
 export { Release, CompatibilityResult, createRelease, createReleaseFromChart, promoteRelease, reportCompatibilityResult } from "./releases";
-export { VM, createVM } from "./vms";
+export { VM, createVM, pollForVMStatus } from "./vms";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { Channel, createChannel, getChannelDetails, archiveChannel, pollForAirga
 export { ClusterVersion, createCluster, createClusterWithLicense, pollForStatus, getKubeconfig, removeCluster, upgradeCluster, getClusterVersions, createAddonObjectStore, pollForAddonStatus, exposeClusterPort } from "./clusters";
 export { KubernetesDistribution, CustomerSummary, CreateCustomerOptions, archiveCustomer, createCustomer, getUsedKubernetesDistributions, listCustomersByName, listCustomersByEmail } from "./customers";
 export { Release, CompatibilityResult, createRelease, createReleaseFromChart, promoteRelease, reportCompatibilityResult } from "./releases";
+export { VM, createVM } from "./vms";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export { Channel, createChannel, getChannelDetails, archiveChannel, pollForAirga
 export { ClusterVersion, createCluster, createClusterWithLicense, pollForStatus, getKubeconfig, removeCluster, upgradeCluster, getClusterVersions, createAddonObjectStore, pollForAddonStatus, exposeClusterPort } from "./clusters";
 export { KubernetesDistribution, CustomerSummary, CreateCustomerOptions, archiveCustomer, createCustomer, getUsedKubernetesDistributions, listCustomersByName, listCustomersByEmail } from "./customers";
 export { Release, CompatibilityResult, createRelease, createReleaseFromChart, promoteRelease, reportCompatibilityResult } from "./releases";
-export { VM, createVM, pollForVMStatus } from "./vms";
+export { VM, createVM, pollForVMStatus, removeVM } from "./vms";

--- a/src/vms.spec.ts
+++ b/src/vms.spec.ts
@@ -1,5 +1,5 @@
 import { VendorPortalApi } from "./configuration";
-import { createVM, pollForVMStatus } from ".";
+import { createVM, pollForVMStatus, removeVM } from ".";
 import { VM } from "./vms";
 import { StatusError } from "./clusters";
 import * as mockttp from "mockttp";
@@ -101,6 +101,35 @@ describe("VMService use cases", () => {
     const vms: VM[] = await createVM(apiClient, "vm1", "ubuntu", "10m", undefined, undefined, undefined, undefined, ["ssh-rsa AAAA..."]);
     expect(vms).toHaveLength(1);
     expect(vms[0].id).toEqual(expectedVMs.vms[0].id);
+  });
+});
+
+describe("removeVM", () => {
+  const mockServer = mockttp.getLocal();
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeAll(async () => {
+    await mockServer.start();
+    apiClient.endpoint = `http://localhost:${mockServer.port}`;
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  test("should resolve on successful delete", async () => {
+    const vmId = "1234abcd";
+    await mockServer.forDelete(`/vm/${vmId}`).thenReply(200, "{}");
+
+    await expect(removeVM(apiClient, vmId)).resolves.toBeUndefined();
+  });
+
+  test("should throw StatusError on non-200", async () => {
+    const vmId = "9999zzzz";
+    await mockServer.forDelete(`/vm/${vmId}`).thenReply(404);
+
+    await expect(removeVM(apiClient, vmId)).rejects.toThrow(StatusError);
   });
 });
 

--- a/src/vms.spec.ts
+++ b/src/vms.spec.ts
@@ -44,3 +44,61 @@ describe("VMService", () => {
     });
   });
 });
+
+describe("VMService use cases", () => {
+  const mockServer = mockttp.getLocal();
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeAll(async () => {
+    await mockServer.start();
+    apiClient.endpoint = `http://localhost:${mockServer.port}`;
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  test("should return vm with tags", async () => {
+    const expectedVMs = {
+      vms: [{ name: "vm1", id: "1234abcd", status: "provisioning" }]
+    };
+    await mockServer.forPost("/vm").thenReply(201, JSON.stringify(expectedVMs));
+
+    const tags = [{ key: "foo", value: "bar" }];
+
+    const vms: VM[] = await createVM(apiClient, "vm1", "ubuntu", "10m", undefined, undefined, undefined, undefined, undefined, tags);
+    expect(vms).toHaveLength(1);
+    expect(vms[0].name).toEqual(expectedVMs.vms[0].name);
+    expect(vms[0].id).toEqual(expectedVMs.vms[0].id);
+    expect(vms[0].status).toEqual(expectedVMs.vms[0].status);
+  });
+
+  test("should return multiple vms when count > 1", async () => {
+    const expectedVMs = {
+      vms: [
+        { name: "vm1", id: "aaaa1111", status: "provisioning" },
+        { name: "vm1", id: "bbbb2222", status: "provisioning" },
+        { name: "vm1", id: "cccc3333", status: "provisioning" }
+      ]
+    };
+    await mockServer.forPost("/vm").thenReply(201, JSON.stringify(expectedVMs));
+
+    const vms: VM[] = await createVM(apiClient, "vm1", "ubuntu", "10m", undefined, undefined, undefined, 3);
+    expect(vms).toHaveLength(3);
+    expect(vms[0].id).toEqual("aaaa1111");
+    expect(vms[1].id).toEqual("bbbb2222");
+    expect(vms[2].id).toEqual("cccc3333");
+  });
+
+  test("should return vm with public keys", async () => {
+    const expectedVMs = {
+      vms: [{ name: "vm1", id: "1234abcd", status: "provisioning" }]
+    };
+    await mockServer.forPost("/vm").thenReply(201, JSON.stringify(expectedVMs));
+
+    const vms: VM[] = await createVM(apiClient, "vm1", "ubuntu", "10m", undefined, undefined, undefined, undefined, ["ssh-rsa AAAA..."]);
+    expect(vms).toHaveLength(1);
+    expect(vms[0].id).toEqual(expectedVMs.vms[0].id);
+  });
+});

--- a/src/vms.spec.ts
+++ b/src/vms.spec.ts
@@ -1,6 +1,7 @@
 import { VendorPortalApi } from "./configuration";
-import { createVM } from ".";
+import { createVM, pollForVMStatus } from ".";
 import { VM } from "./vms";
+import { StatusError } from "./clusters";
 import * as mockttp from "mockttp";
 
 describe("VMService", () => {
@@ -100,5 +101,51 @@ describe("VMService use cases", () => {
     const vms: VM[] = await createVM(apiClient, "vm1", "ubuntu", "10m", undefined, undefined, undefined, undefined, ["ssh-rsa AAAA..."]);
     expect(vms).toHaveLength(1);
     expect(vms[0].id).toEqual(expectedVMs.vms[0].id);
+  });
+});
+
+describe("pollForVM", () => {
+  const mockServer = mockttp.getLocal();
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeEach(async () => {
+    await mockServer.start();
+    apiClient.endpoint = `http://localhost:${mockServer.port}`;
+  });
+
+  afterEach(async () => {
+    await mockServer.stop();
+  });
+
+  test("should eventually return success with expected status", async () => {
+    const expectedVM = { id: "1234abcd", name: "vm1", status: "running" };
+    const responseVM = { id: "1234abcd", name: "vm1" };
+
+    await mockServer
+      .forGet(`/vm/${responseVM.id}`)
+      .once()
+      .thenReply(200, JSON.stringify({ vm: { ...responseVM, status: "pending" } }));
+    await mockServer
+      .forGet(`/vm/${responseVM.id}`)
+      .once()
+      .thenReply(200, JSON.stringify({ vm: { ...responseVM, status: "provisioning" } }));
+    await mockServer.forGet(`/vm/${responseVM.id}`).once().thenReply(503);
+    await mockServer.forGet(`/vm/${responseVM.id}`).thenReply(200, JSON.stringify({ vm: { ...responseVM, status: "running" } }));
+
+    const vm: VM = await pollForVMStatus(apiClient, "1234abcd", "running", 1, 10);
+    expect(vm).toEqual(expectedVM);
+  });
+
+  test("should still fail on 404", async () => {
+    const responseVM = { id: "1234abcd", name: "vm1" };
+
+    await mockServer
+      .forGet(`/vm/${responseVM.id}`)
+      .once()
+      .thenReply(200, JSON.stringify({ vm: { ...responseVM, status: "pending" } }));
+    await mockServer.forGet(`/vm/${responseVM.id}`).thenReply(404);
+
+    await expect(pollForVMStatus(apiClient, "1234abcd", "running", 1, 10)).rejects.toThrow(StatusError);
   });
 });

--- a/src/vms.spec.ts
+++ b/src/vms.spec.ts
@@ -1,0 +1,46 @@
+import { VendorPortalApi } from "./configuration";
+import { createVM } from ".";
+import { VM } from "./vms";
+import * as mockttp from "mockttp";
+
+describe("VMService", () => {
+  beforeAll(() => globalThis.provider.setup());
+  afterEach(() => globalThis.provider.verify());
+  afterAll(() => globalThis.provider.finalize());
+
+  test("should return vm", () => {
+    const expectedVMs = {
+      vms: [{ name: "vm1", id: "1234abcd", status: "provisioning" }]
+    };
+    const reqBody = {
+      name: "vm1",
+      distribution: "ubuntu",
+      ttl: "10m"
+    };
+    globalThis.provider.addInteraction({
+      state: "vm created",
+      uponReceiving: "a request for creating a vm",
+      withRequest: {
+        method: "POST",
+        path: "/vm",
+        body: reqBody
+      },
+      willRespondWith: {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+        body: expectedVMs
+      }
+    });
+
+    const apiClient = new VendorPortalApi();
+    apiClient.apiToken = "abcd1234";
+    apiClient.endpoint = globalThis.provider.mockService.baseUrl;
+
+    return createVM(apiClient, "vm1", "ubuntu", "10m").then(vms => {
+      expect(vms).toHaveLength(1);
+      expect(vms[0].name).toEqual(expectedVMs.vms[0].name);
+      expect(vms[0].id).toEqual(expectedVMs.vms[0].id);
+      expect(vms[0].status).toEqual(expectedVMs.vms[0].status);
+    });
+  });
+});

--- a/src/vms.ts
+++ b/src/vms.ts
@@ -124,3 +124,14 @@ export async function pollForVMStatus(vendorPortalApi: VendorPortalApi, vmId: st
 
   throw new Error(`VM did not reach state ${expectedStatus} within ${timeout} seconds`);
 }
+
+export async function removeVM(vendorPortalApi: VendorPortalApi, vmId: string) {
+  const http = await vendorPortalApi.client();
+
+  const uri = `${vendorPortalApi.endpoint}/vm/${vmId}`;
+  const res = await http.del(uri);
+  await res.readBody();
+  if (res.message.statusCode != 200) {
+    throw new StatusError(`Failed to remove vm: Server responded with ${res.message.statusCode}`, res.message.statusCode);
+  }
+}

--- a/src/vms.ts
+++ b/src/vms.ts
@@ -71,3 +71,56 @@ export async function createVM(
     status: v.status
   }));
 }
+
+async function getVMDetails(vendorPortalApi: VendorPortalApi, vmId: string): Promise<VM> {
+  const http = await vendorPortalApi.client();
+
+  const uri = `${vendorPortalApi.endpoint}/vm/${vmId}`;
+  const res = await http.get(uri);
+  if (res.message.statusCode != 200) {
+    await res.readBody();
+    throw new StatusError(`Failed to get vm: Server responded with ${res.message.statusCode}`, res.message.statusCode);
+  }
+
+  const body: any = JSON.parse(await res.readBody());
+
+  return {
+    name: body.vm.name,
+    id: body.vm.id,
+    status: body.vm.status
+  };
+}
+
+export async function pollForVMStatus(vendorPortalApi: VendorPortalApi, vmId: string, expectedStatus: string, timeout: number = 120, sleeptimeMs: number = 5000): Promise<VM> {
+  await new Promise(f => setTimeout(f, sleeptimeMs));
+  const iterations = (timeout * 1000) / sleeptimeMs;
+  for (let i = 0; i < iterations; i++) {
+    try {
+      const vmDetails = await getVMDetails(vendorPortalApi, vmId);
+      if (vmDetails.status === expectedStatus) {
+        return vmDetails;
+      }
+
+      if (vmDetails.status === "error") {
+        throw new Error(`VM has entered error state`);
+      }
+
+      console.debug(`VM status is ${vmDetails.status}, sleeping for ${sleeptimeMs / 1000} seconds`);
+    } catch (err) {
+      if (err instanceof StatusError) {
+        if (err.statusCode >= 500) {
+          console.debug(`Got HTTP error with status ${err.statusCode}, sleeping for ${sleeptimeMs / 1000} seconds`);
+        } else {
+          console.debug(`Got HTTP error with status ${err.statusCode}, exiting`);
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+    }
+
+    await new Promise(f => setTimeout(f, sleeptimeMs));
+  }
+
+  throw new Error(`VM did not reach state ${expectedStatus} within ${timeout} seconds`);
+}

--- a/src/vms.ts
+++ b/src/vms.ts
@@ -1,0 +1,73 @@
+import { VendorPortalApi } from "./configuration";
+import { StatusError } from "./clusters";
+
+export class VM {
+  name: string;
+  id: string;
+  status: string;
+}
+
+interface tag {
+  key: string;
+  value: string;
+}
+
+export async function createVM(
+  vendorPortalApi: VendorPortalApi,
+  name: string,
+  distribution: string,
+  vmTTL: string,
+  version?: string,
+  diskGib?: number,
+  instanceType?: string,
+  count?: number,
+  publicKeys?: string[],
+  tags?: tag[]
+): Promise<VM[]> {
+  const http = await vendorPortalApi.client();
+
+  const reqBody: any = {
+    name: name,
+    distribution: distribution,
+    ttl: vmTTL
+  };
+  if (version) {
+    reqBody["version"] = version;
+  }
+  if (diskGib) {
+    reqBody["disk_gib"] = diskGib;
+  }
+  if (instanceType) {
+    reqBody["instance_type"] = instanceType;
+  }
+  if (count) {
+    reqBody["count"] = count;
+  }
+  if (publicKeys && publicKeys.length > 0) {
+    reqBody["public_keys"] = publicKeys;
+  }
+  if (tags) {
+    reqBody["tags"] = tags;
+  }
+
+  const uri = `${vendorPortalApi.endpoint}/vm`;
+  const res = await http.post(uri, JSON.stringify(reqBody));
+  if (res.message.statusCode != 201) {
+    let body = "";
+    try {
+      body = await res.readBody();
+    } catch (err) {
+      // ignore
+    }
+    throw new Error(`Failed to queue vm create: Server responded with ${res.message.statusCode}: ${body}`);
+  }
+
+  const body: any = JSON.parse(await res.readBody());
+
+  const vmsArray: any[] = Array.isArray(body.vms) ? body.vms : body.vm ? [body.vm] : [];
+  return vmsArray.map(v => ({
+    name: v.name,
+    id: v.id,
+    status: v.status
+  }));
+}

--- a/src/vms.ts
+++ b/src/vms.ts
@@ -12,18 +12,7 @@ interface tag {
   value: string;
 }
 
-export async function createVM(
-  vendorPortalApi: VendorPortalApi,
-  name: string,
-  distribution: string,
-  vmTTL: string,
-  version?: string,
-  diskGib?: number,
-  instanceType?: string,
-  count?: number,
-  publicKeys?: string[],
-  tags?: tag[]
-): Promise<VM[]> {
+export async function createVM(vendorPortalApi: VendorPortalApi, name: string, distribution: string, vmTTL: string, version?: string, diskGib?: number, instanceType?: string, count?: number, publicKeys?: string[], tags?: tag[]): Promise<VM[]> {
   const http = await vendorPortalApi.client();
 
   const reqBody: any = {


### PR DESCRIPTION
## Summary

- Adds VM lifecycle management to the SDK in `src/vms.ts`, mirroring the existing cluster management pattern
- New public API: `createVM`, `pollForVMStatus`, `removeVM`, and a `VM` type — all re-exported from `src/index.ts`
- Pact contract test for `createVM` plus mockttp-based tests covering tags, count > 1, public keys, polling (5xx retry, 404 failure), and delete success/failure

### API

```ts
createVM(api, name, distribution, vmTTL, version?, diskGib?, instanceType?, count?, publicKeys?, tags?): Promise<VM[]>
pollForVMStatus(api, vmId, expectedStatus, timeout=120, sleeptimeMs=5000): Promise<VM>
removeVM(api, vmId): Promise<void>
```

### Out of scope (future follow-ups)

- `network_id` param on create
- VM versions endpoint, update TTL, port exposure, SSH/SCP endpoints

## Test plan

- [ ] `npm test` — all VM tests (8) pass (pre-existing `releases.spec.ts` socket-hang-up flakes on `main` are unrelated)
- [ ] `npm run build` — clean TypeScript compile
- [ ] `dist/index.js` exports `VM`, `createVM`, `pollForVMStatus`, `removeVM`
- [ ] Pact file regenerated with the new `/vm` create interaction