### PR TITLE
feat: add network update and report APIs; surface network_id on clusters and VMs

### DIFF
--- a/src/clusters.ts
+++ b/src/clusters.ts
@@ -5,6 +5,7 @@ export class Cluster {
   id: string;
   status: string;
   last_scheduling_status?: string;
+  network_id?: string;
 }
 
 export class ClusterVersion {
@@ -159,7 +160,8 @@ export async function createClusterWithLicense(
   return {
     name: body.cluster.name,
     id: body.cluster.id,
-    status: body.cluster.status
+    status: body.cluster.status,
+    network_id: body.cluster.network_id
   };
 }
 
@@ -221,7 +223,8 @@ async function getClusterDetails(vendorPortalApi: VendorPortalApi, clusterId: st
     name: body.cluster.name,
     id: body.cluster.id,
     status: body.cluster.status,
-    last_scheduling_status: body.cluster.last_scheduling_status
+    last_scheduling_status: body.cluster.last_scheduling_status,
+    network_id: body.cluster.network_id
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export { ClusterVersion, createCluster, createClusterWithLicense, pollForStatus,
 export { KubernetesDistribution, CustomerSummary, CreateCustomerOptions, archiveCustomer, createCustomer, getUsedKubernetesDistributions, listCustomersByName, listCustomersByEmail } from "./customers";
 export { Release, CompatibilityResult, createRelease, createReleaseFromChart, promoteRelease, reportCompatibilityResult } from "./releases";
 export { VM, createVM, pollForVMStatus, removeVM } from "./vms";
-export { Network, UpdateNetworkOptions, updateNetwork } from "./networks";
+export { Network, UpdateNetworkOptions, NetworkReport, NetworkEventData, NetworkReportSummary, NetworkReportSummaryDomain, NetworkReportSummaryDestination, NetworkReportSummarySource, updateNetwork, getNetworkReport, getNetworkReportSummary } from "./networks";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { ClusterVersion, createCluster, createClusterWithLicense, pollForStatus,
 export { KubernetesDistribution, CustomerSummary, CreateCustomerOptions, archiveCustomer, createCustomer, getUsedKubernetesDistributions, listCustomersByName, listCustomersByEmail } from "./customers";
 export { Release, CompatibilityResult, createRelease, createReleaseFromChart, promoteRelease, reportCompatibilityResult } from "./releases";
 export { VM, createVM, pollForVMStatus, removeVM } from "./vms";
+export { Network, UpdateNetworkOptions, updateNetwork } from "./networks";

--- a/src/networks.spec.ts
+++ b/src/networks.spec.ts
@@ -109,7 +109,10 @@ describe("getNetworkReport", () => {
     const after = new Date("2026-04-27T10:00:00.000Z");
     await getNetworkReport(apiClient, networkId, after);
 
-    const requests = await mockServer.getMockedEndpoints().then(eps => Promise.all(eps.map(ep => ep.getSeenRequests()))).then(rs => rs.flat());
+    const requests = await mockServer
+      .getMockedEndpoints()
+      .then(eps => Promise.all(eps.map(ep => ep.getSeenRequests())))
+      .then(rs => rs.flat());
     const matching = requests.filter(r => r.url.includes(`/network/${networkId}/report`));
     expect(matching.length).toBeGreaterThan(0);
     expect(matching[0].url).toContain(`after=${encodeURIComponent("2026-04-27T10:00:00.000Z")}`);

--- a/src/networks.spec.ts
+++ b/src/networks.spec.ts
@@ -1,6 +1,6 @@
 import { VendorPortalApi } from "./configuration";
-import { updateNetwork } from ".";
-import { Network } from "./networks";
+import { updateNetwork, getNetworkReport, getNetworkReportSummary } from ".";
+import { Network, NetworkReport, NetworkReportSummary } from "./networks";
 import { StatusError } from "./clusters";
 import * as mockttp from "mockttp";
 
@@ -69,5 +69,125 @@ describe("updateNetwork", () => {
     await mockServer.forPut(`/network/${networkId}/update`).thenReply(404, JSON.stringify({ error: { message: "not found" } }));
 
     await expect(updateNetwork(apiClient, networkId, { policy: "airgap" })).rejects.toThrow(StatusError);
+  });
+});
+
+describe("getNetworkReport", () => {
+  const mockServer = mockttp.getLocal();
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeAll(async () => {
+    await mockServer.start();
+    apiClient.endpoint = `http://localhost:${mockServer.port}`;
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  test("should return events", async () => {
+    const networkId = "net-1234";
+    const expected = {
+      events: [
+        { timestamp: "2026-04-27T10:00:00Z", srcIp: "10.0.0.1", dstIp: "1.2.3.4", dstPort: 443, proto: "tcp" },
+        { timestamp: "2026-04-27T10:00:01Z", srcIp: "10.0.0.1", dstIp: "5.6.7.8", dstPort: 80, proto: "tcp" }
+      ]
+    };
+    await mockServer.forGet(`/network/${networkId}/report`).thenReply(200, JSON.stringify(expected));
+
+    const report: NetworkReport = await getNetworkReport(apiClient, networkId);
+    expect(report.events).toHaveLength(2);
+    expect(report.events[0].srcIp).toEqual("10.0.0.1");
+    expect(report.events[1].dstPort).toEqual(80);
+  });
+
+  test("should send after as RFC3339 query param", async () => {
+    const networkId = "net-after";
+    await mockServer.forGet(`/network/${networkId}/report`).thenReply(200, JSON.stringify({ events: [] }));
+
+    const after = new Date("2026-04-27T10:00:00.000Z");
+    await getNetworkReport(apiClient, networkId, after);
+
+    const requests = await mockServer.getMockedEndpoints().then(eps => Promise.all(eps.map(ep => ep.getSeenRequests()))).then(rs => rs.flat());
+    const matching = requests.filter(r => r.url.includes(`/network/${networkId}/report`));
+    expect(matching.length).toBeGreaterThan(0);
+    expect(matching[0].url).toContain(`after=${encodeURIComponent("2026-04-27T10:00:00.000Z")}`);
+  });
+
+  test("should default events to empty array when missing", async () => {
+    const networkId = "net-empty";
+    await mockServer.forGet(`/network/${networkId}/report`).thenReply(200, JSON.stringify({}));
+
+    const report: NetworkReport = await getNetworkReport(apiClient, networkId);
+    expect(report.events).toEqual([]);
+  });
+
+  test("should throw StatusError on non-200", async () => {
+    const networkId = "net-bad";
+    await mockServer.forGet(`/network/${networkId}/report`).thenReply(404);
+
+    await expect(getNetworkReport(apiClient, networkId)).rejects.toThrow(StatusError);
+  });
+});
+
+describe("getNetworkReportSummary", () => {
+  const mockServer = mockttp.getLocal();
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeAll(async () => {
+    await mockServer.start();
+    apiClient.endpoint = `http://localhost:${mockServer.port}`;
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  test("should return summary", async () => {
+    const networkId = "net-1234";
+    const expected = {
+      id: "summary-1",
+      network_id: networkId,
+      total_events: 42,
+      time_range_start: "2026-04-27T09:00:00Z",
+      time_range_end: "2026-04-27T11:00:00Z",
+      created_at: "2026-04-27T11:01:00Z",
+      domains: [{ id: "d1", domain: "example.com", count: 10 }],
+      destinations: [
+        {
+          id: "dst1",
+          ip: "1.2.3.4",
+          protocol: "tcp",
+          port: 443,
+          count: 5,
+          sources: [{ id: "s1", ip: "10.0.0.1", pod: "app-1" }]
+        }
+      ]
+    };
+    await mockServer.forGet(`/network/${networkId}/report/summary`).thenReply(200, JSON.stringify(expected));
+
+    const summary: NetworkReportSummary = await getNetworkReportSummary(apiClient, networkId);
+    expect(summary.id).toEqual("summary-1");
+    expect(summary.network_id).toEqual(networkId);
+    expect(summary.total_events).toEqual(42);
+    expect(summary.domains).toHaveLength(1);
+    expect(summary.domains?.[0].domain).toEqual("example.com");
+    expect(summary.destinations?.[0].sources?.[0].pod).toEqual("app-1");
+  });
+
+  test("should throw on api error in body", async () => {
+    const networkId = "net-err";
+    await mockServer.forGet(`/network/${networkId}/report/summary`).thenReply(200, JSON.stringify({ error: "no summary" }));
+
+    await expect(getNetworkReportSummary(apiClient, networkId)).rejects.toThrow("no summary");
+  });
+
+  test("should throw StatusError on non-200", async () => {
+    const networkId = "net-404";
+    await mockServer.forGet(`/network/${networkId}/report/summary`).thenReply(404);
+
+    await expect(getNetworkReportSummary(apiClient, networkId)).rejects.toThrow(StatusError);
   });
 });

--- a/src/networks.spec.ts
+++ b/src/networks.spec.ts
@@ -1,0 +1,73 @@
+import { VendorPortalApi } from "./configuration";
+import { updateNetwork } from ".";
+import { Network } from "./networks";
+import { StatusError } from "./clusters";
+import * as mockttp from "mockttp";
+
+describe("updateNetwork", () => {
+  const mockServer = mockttp.getLocal();
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeAll(async () => {
+    await mockServer.start();
+    apiClient.endpoint = `http://localhost:${mockServer.port}`;
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  test("should update policy", async () => {
+    const networkId = "net-1234";
+    const expected = {
+      network: { id: networkId, name: "net1", status: "running", policy: "airgap", collect_report: false }
+    };
+    const endpoint = await mockServer.forPut(`/network/${networkId}/update`).thenReply(200, JSON.stringify(expected));
+
+    const network: Network = await updateNetwork(apiClient, networkId, { policy: "airgap" });
+    expect(network.id).toEqual(networkId);
+    expect(network.policy).toEqual("airgap");
+    expect(network.collect_report).toEqual(false);
+
+    const requests = await endpoint.getSeenRequests();
+    expect(requests).toHaveLength(1);
+    expect(await requests[0].body.getJson()).toEqual({ policy: "airgap" });
+  });
+
+  test("should enable collect-report", async () => {
+    const networkId = "net-5678";
+    const expected = {
+      network: { id: networkId, name: "net1", status: "running", policy: "open", collect_report: true }
+    };
+    const endpoint = await mockServer.forPut(`/network/${networkId}/update`).thenReply(200, JSON.stringify(expected));
+
+    const network: Network = await updateNetwork(apiClient, networkId, { collectReport: true });
+    expect(network.collect_report).toEqual(true);
+
+    const requests = await endpoint.getSeenRequests();
+    expect(requests).toHaveLength(1);
+    expect(await requests[0].body.getJson()).toEqual({ policy: "", collect_report: true });
+  });
+
+  test("should send both policy and collect-report when provided", async () => {
+    const networkId = "net-9999";
+    const expected = {
+      network: { id: networkId, name: "net1", status: "running", policy: "airgap", collect_report: true }
+    };
+    const endpoint = await mockServer.forPut(`/network/${networkId}/update`).thenReply(200, JSON.stringify(expected));
+
+    await updateNetwork(apiClient, networkId, { policy: "airgap", collectReport: true });
+
+    const requests = await endpoint.getSeenRequests();
+    expect(requests).toHaveLength(1);
+    expect(await requests[0].body.getJson()).toEqual({ policy: "airgap", collect_report: true });
+  });
+
+  test("should throw StatusError on non-200", async () => {
+    const networkId = "net-bad";
+    await mockServer.forPut(`/network/${networkId}/update`).thenReply(404, JSON.stringify({ error: { message: "not found" } }));
+
+    await expect(updateNetwork(apiClient, networkId, { policy: "airgap" })).rejects.toThrow(StatusError);
+  });
+});

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -14,6 +14,59 @@ export interface UpdateNetworkOptions {
   collectReport?: boolean;
 }
 
+export class NetworkEventData {
+  timestamp?: string;
+  srcIp?: string;
+  dstIp?: string;
+  srcPort?: number;
+  dstPort?: number;
+  sourcePod?: string;
+  dstPod?: string;
+  proto?: string;
+  comm?: string;
+  pid?: number;
+  likelyService?: string;
+  dnsQueryName?: string;
+}
+
+export class NetworkReport {
+  events: NetworkEventData[];
+}
+
+export class NetworkReportSummarySource {
+  id: string;
+  ip?: string;
+  service?: string;
+  command?: string;
+  pod?: string;
+}
+
+export class NetworkReportSummaryDestination {
+  id: string;
+  ip?: string;
+  protocol?: string;
+  port?: number;
+  count?: number;
+  sources?: NetworkReportSummarySource[];
+}
+
+export class NetworkReportSummaryDomain {
+  id: string;
+  domain: string;
+  count: number;
+}
+
+export class NetworkReportSummary {
+  id: string;
+  network_id: string;
+  total_events: number;
+  time_range_start: string;
+  time_range_end: string;
+  created_at: string;
+  domains?: NetworkReportSummaryDomain[];
+  destinations?: NetworkReportSummaryDestination[];
+}
+
 export async function updateNetwork(vendorPortalApi: VendorPortalApi, networkId: string, options: UpdateNetworkOptions): Promise<Network> {
   const http = await vendorPortalApi.client();
 
@@ -44,5 +97,53 @@ export async function updateNetwork(vendorPortalApi: VendorPortalApi, networkId:
     status: body.network.status,
     policy: body.network.policy,
     collect_report: body.network.collect_report
+  };
+}
+
+export async function getNetworkReport(vendorPortalApi: VendorPortalApi, networkId: string, after?: Date): Promise<NetworkReport> {
+  const http = await vendorPortalApi.client();
+
+  let uri = `${vendorPortalApi.endpoint}/network/${networkId}/report`;
+  if (after) {
+    uri = `${uri}?after=${encodeURIComponent(after.toISOString())}`;
+  }
+
+  const res = await http.get(uri);
+  if (res.message.statusCode != 200) {
+    await res.readBody();
+    throw new StatusError(`Failed to get network report: Server responded with ${res.message.statusCode}`, res.message.statusCode);
+  }
+
+  const body: any = JSON.parse(await res.readBody());
+
+  return {
+    events: Array.isArray(body.events) ? body.events : []
+  };
+}
+
+export async function getNetworkReportSummary(vendorPortalApi: VendorPortalApi, networkId: string): Promise<NetworkReportSummary> {
+  const http = await vendorPortalApi.client();
+
+  const uri = `${vendorPortalApi.endpoint}/network/${networkId}/report/summary`;
+  const res = await http.get(uri);
+  if (res.message.statusCode != 200) {
+    await res.readBody();
+    throw new StatusError(`Failed to get network report summary: Server responded with ${res.message.statusCode}`, res.message.statusCode);
+  }
+
+  const body: any = JSON.parse(await res.readBody());
+  if (body.error) {
+    throw new Error(`Failed to get network report summary: ${body.error}`);
+  }
+
+  return {
+    id: body.id,
+    network_id: body.network_id,
+    total_events: body.total_events,
+    time_range_start: body.time_range_start,
+    time_range_end: body.time_range_end,
+    created_at: body.created_at,
+    domains: body.domains,
+    destinations: body.destinations
   };
 }

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,0 +1,48 @@
+import { VendorPortalApi } from "./configuration";
+import { StatusError } from "./clusters";
+
+export class Network {
+  id: string;
+  name: string;
+  status: string;
+  policy?: string;
+  collect_report?: boolean;
+}
+
+export interface UpdateNetworkOptions {
+  policy?: string;
+  collectReport?: boolean;
+}
+
+export async function updateNetwork(vendorPortalApi: VendorPortalApi, networkId: string, options: UpdateNetworkOptions): Promise<Network> {
+  const http = await vendorPortalApi.client();
+
+  const reqBody: any = {
+    policy: options.policy ?? ""
+  };
+  if (options.collectReport !== undefined) {
+    reqBody["collect_report"] = options.collectReport;
+  }
+
+  const uri = `${vendorPortalApi.endpoint}/network/${networkId}/update`;
+  const res = await http.put(uri, JSON.stringify(reqBody));
+  if (res.message.statusCode != 200) {
+    let body = "";
+    try {
+      body = await res.readBody();
+    } catch (err) {
+      // ignore
+    }
+    throw new StatusError(`Failed to update network: Server responded with ${res.message.statusCode}: ${body}`, res.message.statusCode);
+  }
+
+  const body: any = JSON.parse(await res.readBody());
+
+  return {
+    id: body.network.id,
+    name: body.network.name,
+    status: body.network.status,
+    policy: body.network.policy,
+    collect_report: body.network.collect_report
+  };
+}

--- a/src/vms.ts
+++ b/src/vms.ts
@@ -5,6 +5,7 @@ export class VM {
   name: string;
   id: string;
   status: string;
+  network_id?: string;
 }
 
 interface tag {
@@ -57,7 +58,8 @@ export async function createVM(vendorPortalApi: VendorPortalApi, name: string, d
   return vmsArray.map(v => ({
     name: v.name,
     id: v.id,
-    status: v.status
+    status: v.status,
+    network_id: v.network_id
   }));
 }
 
@@ -76,7 +78,8 @@ async function getVMDetails(vendorPortalApi: VendorPortalApi, vmId: string): Pro
   return {
     name: body.vm.name,
     id: body.vm.id,
-    status: body.vm.status
+    status: body.vm.status,
+    network_id: body.vm.network_id
   };
 }
 


### PR DESCRIPTION
## Summary
- **`updateNetwork(api, networkId, { policy?, collectReport? })`** — `PUT /network/{id}/update`. Supports policy values `open`/`airgap` and toggling `collect_report`. Always sends `policy`, includes `collect_report` only when explicitly set, mirroring the upstream Go vendor client.
- **`getNetworkReport(api, networkId, after?: Date)`** — `GET /network/{id}/report`. Returns raw `NetworkEventData[]`. Optional `after` Date narrows to events newer than that timestamp (encoded as RFC3339).
- **`getNetworkReportSummary(api, networkId)`** — `GET /network/{id}/report/summary`. Returns aggregated stats with top domains/destinations. Two separate functions instead of a boolean flag — distinct return types, no narrowing at call sites, room for per-mode params (e.g., `after` on events).
- **Expose `network_id` on `Cluster` and `VM`**, populated from `createCluster` / `createClusterWithLicense` / `getClusterDetails` and `createVM` / `getVMDetails`, so callers can drive network updates without an extra lookup.

## Test plan
- [x] `npm run build` (clean)
- [x] `npx jest src/networks.spec.ts src/clusters.spec.ts src/vms.spec.ts` — 30/30 pass
- [x] `networks.spec.ts` covers: policy-only update, collect-report-only, both fields, `StatusError` on non-200; report event listing, `after` query param, empty events default, summary parsing with domains/destinations/sources, summary error body, and 4xx StatusError paths