### PR TITLE
Adds three functions used by replicated-actions to surface airgap build failures

### DIFF
--- a/src/channels.spec.ts
+++ b/src/channels.spec.ts
@@ -1,5 +1,5 @@
 import { Interaction } from "@pact-foundation/pact";
-import { exportedForTesting, createChannel, pollForAirgapReleaseStatus, getDownloadUrlAirgapBuildRelease } from "./channels";
+import { exportedForTesting, createChannel, pollForAirgapReleaseStatus, getDownloadUrlAirgapBuildRelease, getAirgapBuildStatus, getLatestAirgapStatusForRelease, getAirgapBundleDownloadURL } from "./channels";
 import { VendorPortalApi } from "./configuration";
 import * as mockttp from "mockttp";
 
@@ -221,5 +221,144 @@ describe("getDownloadUrlAirgapBuildRelease", () => {
 
     const downloadUrlResult = await getDownloadUrlAirgapBuildRelease(apiClient, "1234abcd", "1", 0);
     expect(downloadUrlResult).toEqual("https://s3.amazonaws.com/airgap.replicated.com/xxxxxxxxx/7.airgap?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=xxxxxx%2F20250317%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=");
+  });
+});
+
+describe("getAirgapBuildStatus", () => {
+  let mockServer: mockttp.Mockttp;
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeEach(async () => {
+    mockServer = mockttp.getLocal();
+    await mockServer.start();
+    apiClient.endpoint = "http://localhost:" + mockServer.port;
+  });
+  afterEach(async () => {
+    await mockServer.stop();
+  });
+
+  it("returns the airgap build status for a known channel-release", async () => {
+    const statusBody = {
+      channelId: "1234abcd",
+      channelSequence: 7,
+      channelName: "Stable",
+      airgapBuildStatus: "built",
+      airgapBuildError: "",
+      fullAirgapBuild: true
+    };
+    await mockServer.forGet("/app/app1/channel/1234abcd/release/7/airgap/status").once().thenReply(200, JSON.stringify(statusBody));
+
+    const result = await getAirgapBuildStatus(apiClient, "app1", "1234abcd", 7);
+    expect(result).not.toBeNull();
+    expect(result!.airgapBuildStatus).toBe("built");
+    expect(result!.fullAirgapBuild).toBe(true);
+    expect(result!.channelName).toBe("Stable");
+  });
+
+  it("returns the synthesized pending status when the worker has not started yet", async () => {
+    const statusBody = {
+      channelId: "1234abcd",
+      channelSequence: 7,
+      channelName: "Stable",
+      airgapBuildStatus: "pending",
+      airgapBuildError: ""
+    };
+    await mockServer.forGet("/app/app1/channel/1234abcd/release/7/airgap/status").once().thenReply(200, JSON.stringify(statusBody));
+
+    const result = await getAirgapBuildStatus(apiClient, "app1", "1234abcd", 7);
+    expect(result!.airgapBuildStatus).toBe("pending");
+  });
+
+  it("returns null on 404", async () => {
+    await mockServer.forGet("/app/app1/channel/1234abcd/release/7/airgap/status").once().thenReply(404, "");
+
+    const result = await getAirgapBuildStatus(apiClient, "app1", "1234abcd", 7);
+    expect(result).toBeNull();
+  });
+
+  it("throws on non-200 / non-404 responses", async () => {
+    await mockServer.forGet("/app/app1/channel/1234abcd/release/7/airgap/status").once().thenReply(500, "");
+
+    await expect(getAirgapBuildStatus(apiClient, "app1", "1234abcd", 7)).rejects.toThrow(/500/);
+  });
+});
+
+describe("getLatestAirgapStatusForRelease", () => {
+  let mockServer: mockttp.Mockttp;
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeEach(async () => {
+    mockServer = mockttp.getLocal();
+    await mockServer.start();
+    apiClient.endpoint = "http://localhost:" + mockServer.port;
+  });
+  afterEach(async () => {
+    await mockServer.stop();
+  });
+
+  it("picks the most recent channelSequence when a release was promoted multiple times", async () => {
+    // Same release (sequence 5) was promoted twice, producing two channel-releases.
+    // The second promote (channelSequence 12) is the one the caller is waiting on.
+    const releaseData = {
+      releases: [
+        { sequence: 5, channelSequence: 9, channelName: "Stable", airgapBuildStatus: "failed", airgapBuildError: "old failure" },
+        { sequence: 5, channelSequence: 12, channelName: "Stable", airgapBuildStatus: "building", airgapBuildError: "" },
+        { sequence: 6, channelSequence: 13, channelName: "Stable", airgapBuildStatus: "pending", airgapBuildError: "" }
+      ]
+    };
+    await mockServer.forGet("/app/app1/channel/1234abcd/releases").once().thenReply(200, JSON.stringify(releaseData));
+
+    const result = await getLatestAirgapStatusForRelease(apiClient, "app1", "1234abcd", 5);
+    expect(result).not.toBeNull();
+    expect(result!.channelSequence).toBe(12);
+    expect(result!.airgapBuildStatus).toBe("building");
+  });
+
+  it("returns null when the release sequence has no channel-releases", async () => {
+    const releaseData = {
+      releases: [{ sequence: 5, channelSequence: 9, airgapBuildStatus: "built" }]
+    };
+    await mockServer.forGet("/app/app1/channel/1234abcd/releases").once().thenReply(200, JSON.stringify(releaseData));
+
+    const result = await getLatestAirgapStatusForRelease(apiClient, "app1", "1234abcd", 99);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response has no releases array", async () => {
+    await mockServer.forGet("/app/app1/channel/1234abcd/releases").once().thenReply(200, JSON.stringify({}));
+
+    const result = await getLatestAirgapStatusForRelease(apiClient, "app1", "1234abcd", 5);
+    expect(result).toBeNull();
+  });
+});
+
+describe("getAirgapBundleDownloadURL", () => {
+  let mockServer: mockttp.Mockttp;
+  const apiClient = new VendorPortalApi();
+  apiClient.apiToken = "abcd1234";
+
+  beforeEach(async () => {
+    mockServer = mockttp.getLocal();
+    await mockServer.start();
+    apiClient.endpoint = "http://localhost:" + mockServer.port;
+  });
+  afterEach(async () => {
+    await mockServer.stop();
+  });
+
+  it("fetches the download URL for a known channelSequence without scraping /releases", async () => {
+    const downloadUrlData = { url: "https://s3.amazonaws.com/airgap.replicated.com/xxx/7.airgap?sig=abc" };
+    await mockServer.forGet("/app/app1/channel/1234abcd/airgap/download-url").withQuery({ channelSequence: 7 }).once().thenReply(200, JSON.stringify(downloadUrlData));
+
+    const url = await getAirgapBundleDownloadURL(apiClient, "app1", "1234abcd", 7);
+    expect(url).toBe("https://s3.amazonaws.com/airgap.replicated.com/xxx/7.airgap?sig=abc");
+  });
+
+  it("throws on non-200 responses", async () => {
+    await mockServer.forGet("/app/app1/channel/1234abcd/airgap/download-url").withQuery({ channelSequence: 7 }).once().thenReply(500, "");
+
+    await expect(getAirgapBundleDownloadURL(apiClient, "app1", "1234abcd", 7)).rejects.toThrow(/500/);
   });
 });

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -4,6 +4,20 @@ export interface ChannelRelease {
   sequence: string;
   channelSequence?: string;
   airgapBuildStatus?: string;
+  airgapBuildError?: string;
+}
+
+// AirgapBuildStatus is the wire shape returned by the dedicated
+// /airgap/status endpoint (vendor-api PR replicatedhq/vandoor#9761). The
+// channelName is included to make logging / job summaries easier without an
+// extra channel lookup.
+export interface AirgapBuildStatus {
+  channelId: string;
+  channelSequence: number;
+  channelName: string;
+  airgapBuildStatus: string;
+  airgapBuildError: string;
+  fullAirgapBuild?: boolean;
 }
 
 export class Channel {
@@ -192,4 +206,85 @@ async function getAirgapBuildRelease(vendorPortalApi: VendorPortalApi, appId: st
     channelSequence: release.channelSequence,
     airgapBuildStatus: release.airgapBuildStatus
   };
+}
+
+// getAirgapBuildStatus reads the airgap-build status for a single channel-
+// release using the dedicated GET /v3/app/{appId}/channel/{channelId}/release/
+// {channelSequence}/airgap/status endpoint (vendor-api PR
+// replicatedhq/vandoor#9761). This is the canonical polling entry point for
+// "I just promoted, give me a real-time view of the build" use cases — it
+// returns "pending" (synthesized) when no kots_airgap_build_status row exists
+// yet, building / built / failed / failed_with_metadata / cancelled / warn /
+// metadata once the worker has written one. Returns null on 404.
+export async function getAirgapBuildStatus(vendorPortalApi: VendorPortalApi, appId: string, channelId: string, channelSequence: number): Promise<AirgapBuildStatus | null> {
+  const http = await vendorPortalApi.client();
+  const uri = `${vendorPortalApi.endpoint}/app/${appId}/channel/${channelId}/release/${channelSequence}/airgap/status`;
+  const res = await http.get(uri);
+  if (res.message.statusCode === 404) {
+    await res.readBody();
+    return null;
+  }
+  if (res.message.statusCode !== 200) {
+    await res.readBody();
+    throw new Error(`Failed to get airgap build status: Server responded with ${res.message.statusCode}`);
+  }
+  const body: any = JSON.parse(await res.readBody());
+  return {
+    channelId: body.channelId || channelId,
+    channelSequence: body.channelSequence ?? channelSequence,
+    channelName: body.channelName || "",
+    airgapBuildStatus: body.airgapBuildStatus || "",
+    airgapBuildError: body.airgapBuildError || "",
+    fullAirgapBuild: body.fullAirgapBuild
+  };
+}
+
+// getLatestAirgapStatusForRelease finds the most recent channel-release for
+// the given (channel, release) pair and returns its airgap-build status.
+// A release can be promoted to the same channel multiple times — each promote
+// produces a distinct channelSequence with its own airgap build — and the
+// caller almost always wants the latest one (their freshly-promoted build).
+//
+// Returns null if no channel-release matches the release sequence.
+export async function getLatestAirgapStatusForRelease(vendorPortalApi: VendorPortalApi, appId: string, channelId: string, releaseSequence: number): Promise<AirgapBuildStatus | null> {
+  const http = await vendorPortalApi.client();
+  const uri = `${vendorPortalApi.endpoint}/app/${appId}/channel/${channelId}/releases`;
+  const res = await http.get(uri);
+  if (res.message.statusCode !== 200) {
+    await res.readBody();
+    throw new Error(`Failed to get channel releases: Server responded with ${res.message.statusCode}`);
+  }
+  const body: any = JSON.parse(await res.readBody());
+  if (!body.releases || !Array.isArray(body.releases)) {
+    return null;
+  }
+  const matching = body.releases.filter((r: any) => r.sequence === releaseSequence);
+  if (matching.length === 0) {
+    return null;
+  }
+  const release = matching.reduce((latest: any, r: any) => ((r.channelSequence ?? 0) > (latest.channelSequence ?? 0) ? r : latest));
+  return {
+    channelId: channelId,
+    channelSequence: release.channelSequence ?? 0,
+    channelName: release.channelName || "",
+    airgapBuildStatus: release.airgapBuildStatus || "",
+    airgapBuildError: release.airgapBuildError || "",
+    fullAirgapBuild: release.fullAirgapBuild
+  };
+}
+
+// getAirgapBundleDownloadURL is a variant of getDownloadUrlAirgapBuildRelease
+// that takes a pre-known channelSequence directly. Use this when the caller
+// already has the channelSequence from a promote response or status poll —
+// it skips the redundant /releases scrape that the older function performs.
+export async function getAirgapBundleDownloadURL(vendorPortalApi: VendorPortalApi, appId: string, channelId: string, channelSequence: number): Promise<string> {
+  const http = await vendorPortalApi.client();
+  const uri = `${vendorPortalApi.endpoint}/app/${appId}/channel/${channelId}/airgap/download-url?channelSequence=${channelSequence}`;
+  const res = await http.get(uri);
+  if (res.message.statusCode !== 200) {
+    await res.readBody();
+    throw new Error(`Failed to get airgap bundle download URL: Server responded with ${res.message.statusCode}`);
+  }
+  const body: any = JSON.parse(await res.readBody());
+  return body.url;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { VendorPortalApi } from "./configuration";
 export { getApplicationDetails } from "./applications";
-export { Channel, createChannel, getChannelDetails, archiveChannel, pollForAirgapReleaseStatus, getDownloadUrlAirgapBuildRelease } from "./channels";
+export { Channel, ChannelRelease, AirgapBuildStatus, createChannel, getChannelDetails, archiveChannel, pollForAirgapReleaseStatus, getDownloadUrlAirgapBuildRelease, getAirgapBuildStatus, getLatestAirgapStatusForRelease, getAirgapBundleDownloadURL } from "./channels";
 export { ClusterVersion, createCluster, createClusterWithLicense, pollForStatus, getKubeconfig, removeCluster, upgradeCluster, getClusterVersions, createAddonObjectStore, pollForAddonStatus, exposeClusterPort } from "./clusters";
 export { KubernetesDistribution, CustomerSummary, CreateCustomerOptions, archiveCustomer, createCustomer, getUsedKubernetesDistributions, listCustomersByName, listCustomersByEmail } from "./customers";
 export { Release, CompatibilityResult, createRelease, createReleaseFromChart, promoteRelease, reportCompatibilityResult } from "./releases";


### PR DESCRIPTION
## Summary

Adds three airgap-build helpers used by [replicated-actions#403](https://github.com/replicatedhq/replicated-actions/pull/403) (sc-136443) to surface airgap build failures after a release promotion:

- `getAirgapBuildStatus` — polls the dedicated `/airgap/status` endpoint for a single channel-release. Returns `null` on 404.
- `getLatestAirgapStatusForRelease` — finds the latest channel-release for a given release sequence (handles multi-promote correctly).
- `getAirgapBundleDownloadURL` — variant of `getDownloadUrlAirgapBuildRelease` that takes a pre-known `channelSequence`, skipping the redundant `/releases` scrape.

Also extends `ChannelRelease` with `airgapBuildError` and adds an `AirgapBuildStatus` interface matching the new wire shape from [vandoor#9761](https://github.com/replicatedhq/vandoor/pull/9761).

## Test plan

- [x] `npm run build` — clean
- [x] `npx jest channels.spec` — 15/15 passing (9 new `mockttp`-backed tests covering 200 / pending / 404 / 5xx / multi-promote / no-match / no-releases-array)
- [ ] Once merged + published, [replicated-actions#403](https://github.com/replicatedhq/replicated-actions/pull/403) will be updated to import from this lib instead of inlining the HTTP calls (per [JD's review](https://github.com/replicatedhq/replicated-actions/pull/403#discussion_r...))